### PR TITLE
[fix] resolve cyclic graph introduced by group_op

### DIFF
--- a/onnxifier/graph.py
+++ b/onnxifier/graph.py
@@ -706,7 +706,14 @@ class OnnxGraph(nx.DiGraph):
             }
             self._value_info_update = list(values_map.values())
         graph.ClearField("value_info")
-        for n in nx.topological_sort(self):
+        # check cycles
+        if not nx.is_directed_acyclic_graph(self):
+            node_gen = iter(self)
+            for cycle in nx.simple_cycles(self, length_bound=10):
+                error(f"Cycle detected: {' -> '.join(cycle)}")
+        else:
+            node_gen = nx.topological_sort(self)
+        for n in node_gen:
             graph.node.append(self.nodes[n]["pb"])
         graph.value_info.extend(self._value_info_update)
         model = make_model(

--- a/onnxifier/passes/fusion/group_op.py
+++ b/onnxifier/passes/fusion/group_op.py
@@ -17,10 +17,12 @@ limitations under the License.
 from collections.abc import Mapping, MutableMapping
 from typing import TypeAlias, Union
 
+import networkx as nx
 from onnx import NodeProto
 from onnx.helper import make_function, make_node, make_operatorsetid
 
 from ...graph import OnnxGraph
+from ...logger import debug
 from .. import PASSES
 
 DOMAIN = "org.onnxifier"
@@ -28,21 +30,22 @@ HierType: TypeAlias = Mapping[str, Union[str, "HierType"]]
 MutableHierType: TypeAlias = MutableMapping[str, Union[str, "MutableHierType"]]
 
 
-def _group_operators_recursively(
-    graph: OnnxGraph, hier: HierType, group_name: str
+def _is_unique_constant(graph: OnnxGraph, node: NodeProto) -> bool:
+    """Check if `node` is a Constant node that feeds into only one other node."""
+    if node.op_type != "Constant":
+        return False
+    successors = list(graph.onnx_successors(node))
+    return len(successors) == 1
+
+
+def _make_group(
+    graph: OnnxGraph,
+    nodes: list[NodeProto],
+    group_name: str,
+    force: bool = False,
 ) -> NodeProto:
-    nodes = []
-    for name, hierarchy in hier.items():
-        if isinstance(hierarchy, Mapping):
-            # subgraph node
-            node = _group_operators_recursively(graph, hierarchy, name)
-        else:
-            node = graph.nodes[hierarchy]["pb"]
-        # fuse constants
-        for pred in graph.onnx_predecessors(node):
-            if pred.op_type == "Constant":
-                nodes.append(pred)
-        nodes.append(node)
+    """Create an ONNX function from `nodes`, add the call-node to `graph`,
+    remove the original nodes, and return the call-node."""
     h = graph.onnx_subgraph(nodes)
     h.name = group_name
     func = make_function(
@@ -56,7 +59,7 @@ def _group_operators_recursively(
             make_operatorsetid("", graph.opset_version),
         ],
     )
-    graph.onnx_add_function(func)
+    graph.onnx_add_function(func, force=force)
     hnode = make_node(
         op_type=group_name,
         inputs=[i.name for i in h.input],
@@ -68,6 +71,122 @@ def _group_operators_recursively(
     for n in nodes:
         graph.remove_onnx_node(n)
     return hnode
+
+
+def _group_operators_recursively(
+    graph: OnnxGraph, hier: HierType, group_name: str
+) -> list[NodeProto]:
+    nodes_set = []
+    for name, hierarchy in hier.items():
+        if isinstance(hierarchy, Mapping):
+            # subgraph node
+            nodes = _group_operators_recursively(graph, hierarchy, name)
+        else:
+            nodes = [graph.nodes[hierarchy]["pb"]]
+        # fuse constants
+        for node in nodes:
+            for pred in graph.onnx_predecessors(node):
+                if _is_unique_constant(graph, pred):
+                    nodes_set.append(pred)
+            nodes_set.append(node)
+
+    # Split disconnected components into separate groups
+    h = graph.onnx_subgraph(nodes_set)
+    components = sorted(nx.weakly_connected_components(h), key=min)
+    if len(components) > 1:
+        grouped_nodes = []
+        for idx, component in enumerate(components):
+            component_nodes = [graph.nodes[n]["pb"] for n in component if n in graph]
+            grouped = _make_group(graph, component_nodes, f"{group_name}_{idx}")
+            grouped_nodes.append(grouped)
+        return grouped_nodes
+
+    return [_make_group(graph, nodes_set, group_name)]
+
+
+def _merge_cycles(graph: OnnxGraph, max_iters: int = 100):
+    def _merged_group_name(component: set[str]) -> str:
+        candidates: list[tuple[str, int]] = []
+        for node_name in component:
+            call_node = graph.nodes[node_name]["pb"]
+            func_name = call_node.op_type
+            func = graph.functions.get(func_name)
+            candidates.append((func_name, len(func.node) if func is not None else 1))
+        return min(candidates, key=lambda item: (-item[1], item[0]))[0]
+
+    def _find_cyclic_component() -> set[str] | None:
+        for comp in nx.strongly_connected_components(graph):
+            if len(comp) > 1:
+                return set(comp)
+            [node_name] = list(comp)
+            if graph.has_edge(node_name, node_name):
+                return {node_name}
+        return None
+
+    step = 0
+    cyc_comp = _find_cyclic_component()
+    while cyc_comp is not None and step < max_iters:
+        merged_name = _merged_group_name(cyc_comp)
+        debug(f"grouped graph has cycles: {cyc_comp}->{merged_name}, step={step}")
+        step += 1
+        # Collect the underlying original operator/call nodes from each cyclic
+        # call node by unfolding one level of the function library.
+        body_nodes: list[NodeProto] = []
+        for node_name in cyc_comp:
+            call_node = graph.nodes[node_name]["pb"]
+            func_name = call_node.op_type
+            if func_name in graph.functions:
+                body_nodes.extend(graph.functions[func_name].node)
+            else:
+                body_nodes.append(call_node)
+
+        # Remove the cyclic call nodes from the live graph.
+        for node_name in cyc_comp:
+            graph.remove_onnx_node(graph.nodes[node_name]["pb"])
+
+        # Re-insert the collected body nodes so the graph is a DAG again,
+        # then fuse them into a single new function.
+        dedup_body_nodes = {n.name: n for n in body_nodes}
+        for node in dedup_body_nodes.values():
+            graph.add_onnx_node(node)
+
+        # merge constants
+        for node in list(dedup_body_nodes.values()):
+            for pred in graph.onnx_predecessors(node):
+                if _is_unique_constant(graph, pred):
+                    dedup_body_nodes[pred.name] = pred
+        _make_group(
+            graph,
+            list(dedup_body_nodes.values()),
+            merged_name,
+            force=merged_name in graph.functions,
+        )
+        cyc_comp = _find_cyclic_component()
+
+    if cyc_comp is not None:
+        raise RuntimeError(
+            f"_merge_cycles did not converge within max_iters={max_iters}."
+        )
+
+
+def _prune_unused_functions(graph: OnnxGraph) -> None:
+    reachable: set[str] = set()
+    stack = [graph.nodes[name]["pb"].op_type for name in graph]
+
+    while stack:
+        func_name = stack.pop()
+        if func_name in reachable or func_name not in graph.functions:
+            continue
+        reachable.add(func_name)
+        stack.extend(node.op_type for node in graph.functions[func_name].node)
+
+    removable = [
+        name
+        for name, func in graph.functions.items()
+        if func.domain == DOMAIN and name not in reachable
+    ]
+    for name in removable:
+        del graph.functions[name]
 
 
 @PASSES.register("group", deps=["initializer_to_constant"])
@@ -126,4 +245,6 @@ def group_operators(graph: OnnxGraph, depth: int = 1, sep: str = "/") -> OnnxGra
         if isinstance(hierarchy, Mapping):
             _group_operators_recursively(graph, hierarchy, name)
 
+    _merge_cycles(graph)
+    _prune_unused_functions(graph)
     return graph

--- a/tests/passes/test_group_op.py
+++ b/tests/passes/test_group_op.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import networkx as nx
 import numpy as np
 import onnx
 from onnx.helper import make_graph, make_model, make_node, make_tensor_value_info
@@ -69,7 +70,7 @@ def test_group_operators_recursively():
         },
     }
 
-    node = _group_operators_recursively(graph, hier["act0"], "act0")
+    [node, *_] = _group_operators_recursively(graph, hier["act0"], "act0")
     assert node.name == "act0"
     assert node.input[0] == "X"
     assert node.output[0] == "a2"
@@ -171,3 +172,191 @@ def test_group_depth_3():
     assert m_node.op_type == "m"
     assert m_node.input[0] == "X"
     assert m_node.output[0] == "Y"
+
+
+def test_group_connectivity_split():
+    """Test that disconnected nodes with the same prefix are split into separate
+    groups.
+    """
+    # Create a graph with two disconnected sub-graphs that have the same prefix
+    # Graph 1: X -> Relu (name=/branch/relu0) -> y1
+    # Graph 2: Z -> Relu (name=/branch/relu1) -> y2
+    nodes = [
+        make_node("Relu", inputs=["X"], outputs=["y1"], name="/branch/relu0"),
+        make_node("Relu", inputs=["Z"], outputs=["y2"], name="/branch/relu1"),
+    ]
+    g = make_graph(
+        nodes,
+        name="connectivity_test",
+        inputs=[
+            make_tensor_value_info("X", onnx.TensorProto.FLOAT, [1024]),
+            make_tensor_value_info("Z", onnx.TensorProto.FLOAT, [1024]),
+        ],
+        outputs=[
+            make_tensor_value_info("y1", onnx.TensorProto.FLOAT, [1024]),
+            make_tensor_value_info("y2", onnx.TensorProto.FLOAT, [1024]),
+        ],
+    )
+    model = make_model(
+        g, opset_imports=[ONNXIFIER_OPSET], ir_version=ONNXIFIER_IR_VERSION
+    )
+    onnx.checker.check_model(model)
+
+    graph = OnnxGraph(model)
+    graph = PassManager(
+        ["group"], configs={"group": {"depth": 2, "sep": "/"}}
+    ).optimize(graph, strict=True)
+
+    # The two disconnected relu nodes should be split into separate functions
+    # with names "branch_0" and "branch_1" (or similar)
+    assert "branch_0" in graph.functions
+    assert "branch_1" in graph.functions
+
+    # Check that the original nodes are removed
+    assert "/branch/relu0" not in graph
+    assert "/branch/relu1" not in graph
+
+    # Check that both function call nodes exist in the graph
+    assert "branch_0" in graph
+    assert "branch_1" in graph
+
+
+def test_group_no_cycle_through_split():
+    """Test that splitting disconnected /a nodes prevents a cycle with /b.
+
+    Graph topology:
+        X -> (/a/0) -> (/b/1) -> (/a/1) -> Y
+
+    At depth=1, /a/0 and /a/1 share prefix "a", but they are NOT directly
+    connected — /b/1 sits between them.  If the pass naively grouped /a/0 and
+    /a/1 together, the resulting DAG would be:
+
+        a <-> b  (cycle)
+
+    The correct behaviour is to split "a" into two separate functions:
+        a_0  (contains /a/0)
+        a_1  (contains /a/1)
+
+    so the final DAG is cycle-free:
+        a_0 -> b -> a_1
+    """
+    nodes = [
+        make_node("Relu", inputs=["X"], outputs=["t0"], name="/a/0"),
+        make_node("Relu", inputs=["t0"], outputs=["t1"], name="/b/1"),
+        make_node("Relu", inputs=["t1"], outputs=["Y"], name="/a/1"),
+    ]
+    g = make_graph(
+        nodes,
+        name="cycle_test",
+        inputs=[make_tensor_value_info("X", onnx.TensorProto.FLOAT, [1024])],
+        outputs=[make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [1024])],
+    )
+    model = make_model(
+        g, opset_imports=[ONNXIFIER_OPSET], ir_version=ONNXIFIER_IR_VERSION
+    )
+    onnx.checker.check_model(model)
+
+    graph = OnnxGraph(model)
+    graph = PassManager(
+        ["group"], configs={"group": {"depth": 1, "sep": "/"}}
+    ).optimize(graph, strict=True)
+
+    # The resulting function-call graph must be acyclic
+    assert nx.is_directed_acyclic_graph(graph)
+    # /a/0 and /a/1 must be in separate groups because merging them would
+    # create a cycle  a <-> b.
+    assert "a_0" in graph.functions
+    assert "a_1" in graph.functions
+    assert "b" in graph.functions
+
+    # original nodes are gone
+    assert "/a/0" not in graph
+    assert "/b/1" not in graph
+    assert "/a/1" not in graph
+
+
+def test_group_no_cycle_through_split_nested():
+    """Test cycle prevention with nested hierarchy (depth=2) and 5 nodes.
+
+    Graph topology (linear chain):
+        X -> (/outer/a/n0) -> (/outer/b/n1) -> (/outer/a/n2)
+          -> (/outer/b/n3) -> (/outer/a/n4) -> Y
+
+    At depth=2 the inner grouping is:
+      "a" wants to merge n0, n2, n4 — but they are NOT directly connected
+          (b-nodes sit between them), so they must be split into a_0/a_1/a_2.
+      "b" wants to merge n1, n3 — similarly disconnected → b_0/b_1.
+
+    Naively merging either set would create a cycle in the grouped DAG.
+    After correct connectivity splitting the result must be acyclic:
+        a_0 -> b_0 -> a_1 -> b_1 -> a_2
+    """
+    nodes = [
+        make_node("Relu", inputs=["X"], outputs=["t0"], name="/outer/a/n0"),
+        make_node("Relu", inputs=["t0"], outputs=["t1"], name="/outer/b/n1"),
+        make_node("Relu", inputs=["t1"], outputs=["t2"], name="/outer/a/n2"),
+        make_node("Relu", inputs=["t2"], outputs=["t3"], name="/outer/b/n3"),
+        make_node("Relu", inputs=["t3"], outputs=["Y"], name="/outer/a/n4"),
+    ]
+    g = make_graph(
+        nodes,
+        name="nested_cycle_test",
+        inputs=[make_tensor_value_info("X", onnx.TensorProto.FLOAT, [1024])],
+        outputs=[make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [1024])],
+    )
+    model = make_model(
+        g, opset_imports=[ONNXIFIER_OPSET], ir_version=ONNXIFIER_IR_VERSION
+    )
+    onnx.checker.check_model(model)
+
+    graph = OnnxGraph(model)
+    graph = PassManager(
+        ["group"], configs={"group": {"depth": 2, "sep": "/"}}
+    ).optimize(graph, strict=True)
+
+    # Most important: the grouped graph must remain acyclic
+    assert nx.is_directed_acyclic_graph(graph)
+
+    # "a" splits into 3 disconnected components, "b" into 2
+    assert "a_0" in graph.functions
+    assert "a_1" in graph.functions
+    assert "a_2" in graph.functions
+    assert "b_0" in graph.functions
+    assert "b_1" in graph.functions
+
+    # All original nodes are removed from the main graph
+    assert "/outer/a/n0" not in graph
+    assert "/outer/b/n1" not in graph
+    assert "/outer/a/n2" not in graph
+    assert "/outer/b/n3" not in graph
+    assert "/outer/a/n4" not in graph
+
+
+def test_group_cycle_merge_flat():
+    nodes = [
+        make_node("Relu", inputs=["X"], outputs=["t0"], name="/a/n0"),
+        make_node("Relu", inputs=["t0"], outputs=["t1"], name="/b/n0"),
+        make_node("Relu", inputs=["t0"], outputs=["t2"], name="/b/n1"),
+        make_node(
+            "Concat", inputs=["t0", "t1", "t2"], outputs=["Y"], name="/a/n1", axis=0
+        ),
+    ]
+    g = make_graph(
+        nodes,
+        name="cycle_merge_flat",
+        inputs=[make_tensor_value_info("X", onnx.TensorProto.FLOAT, [1024])],
+        outputs=[make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [1024])],
+    )
+    model = make_model(
+        g, opset_imports=[ONNXIFIER_OPSET], ir_version=ONNXIFIER_IR_VERSION
+    )
+    onnx.checker.check_model(model)
+
+    graph = OnnxGraph(model)
+    graph = PassManager(
+        ["group"], configs={"group": {"depth": 1, "sep": "/"}}
+    ).optimize(graph, strict=True)
+
+    assert nx.is_directed_acyclic_graph(graph)
+    assert "a" in graph.functions
+    assert "b" not in graph.functions


### PR DESCRIPTION
Some graph may lead to cycles if grouping ops with same
prefix.
We try to resolve cycles by merging SCC into one single
subgraph.
