### PR TITLE
[fix] EliminateDuplicatedTranspose made a wrong reshape data

### DIFF
--- a/onnxifier/__init__.py
+++ b/onnxifier/__init__.py
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = "2.0.4"
+__version__ = "2.1.0"
 
 import os
 from collections.abc import Sequence
@@ -144,8 +144,8 @@ __all__ = ["convert", "convert_graph", "PassManager", "OnnxGraph"]
 # make NodeProto hashable using node name
 onnx.NodeProto.__hash__ = lambda self: hash(self.name)  # type: ignore
 
-ONNXIFIER_IR_VERSION = onnx.IR_VERSION_2023_5_5
+ONNXIFIER_IR_VERSION = onnx.IR_VERSION_2024_3_25
 """Currently used IR version, since most runtime supports up to this version."""
 
-ONNXIFIER_OPSET = make_operatorsetid("", 19)
+ONNXIFIER_OPSET = make_operatorsetid("", 20)
 """Currently used opset version, since most runtime supports up to this version."""

--- a/onnxifier/passes/fusion/eliminate_duplicated_ops.py
+++ b/onnxifier/passes/fusion/eliminate_duplicated_ops.py
@@ -131,9 +131,7 @@ class EliminateDuplicatedTranspose(Rewriter):
         # we can simply bridge the original input and final output
         # with a single Reshape for the target shape.
         shape_name = f"{node1.name}/targetShape"
-        shape_const = make_constant(
-            shape_name, np.array([output_shape], dtype=np.int64)
-        )
+        shape_const = make_constant(shape_name, np.array(output_shape, dtype=np.int64))
         reshape_node = make_node(
             "Reshape",
             inputs=[input_name, shape_const.output[0]],

--- a/onnxifier/passes/swap/trt_vit_attention_replace.py
+++ b/onnxifier/passes/swap/trt_vit_attention_replace.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 # pylint: disable=arguments-differ
+import numpy as np
 from onnx import NodeProto
 from onnx.helper import make_tensor_type_proto, make_value_info
 
@@ -24,6 +25,7 @@ from ...domain.trt.ops.vit_attention_plugin import (
     vit_attention_plugin_schema,
 )
 from .. import PASSES
+from ..utils import make_constant
 from .trt_attention_replace import (
     TRTAttentionRewriter,
     _elem_type_from_schema,
@@ -59,9 +61,20 @@ class TRTViTAttentionRewriter(TRTAttentionRewriter):
         ViTAttentionPlugin(q, k, v, cu_seqlens, max_seqlen_carrier) -> (attn_output)
 
     Shared graph inputs are added: cu_seqlens, max_seqlen_carrier.
+
+    Args:
+        bake_cu_seqlens (bool): Whether to bake cu_seqlens as a constant input.
+            If input shapes are static and known, baking cu_seqlens as [0, s0, s0+s1,
+            ..., s0+...+sN]. Defaults to True.
     """
 
-    def rewrite(self, graph: OnnxGraph, nodes: list[NodeProto], **_):
+    def rewrite(
+        self,
+        graph: OnnxGraph,
+        nodes: list[NodeProto],
+        bake_cu_seqlens: bool = True,
+        **_,
+    ):
         node = nodes[0]
         orig_q_input = node.input[0]
         q_shape = graph.tensor_shape(node.input[0])
@@ -82,7 +95,8 @@ class TRTViTAttentionRewriter(TRTAttentionRewriter):
 
         plugin_op = from_onnx_attention(node, head_size, **plugin_kwargs)
         _ensure_trt_opset(graph)
-        self._add_shared_inputs(graph)
+        if not bake_cu_seqlens or not self._bake_seqlens(graph, plugin_op):
+            self._add_shared_inputs(graph)
         self -= node
         self += plugin_op
         self._collect_plugin_value_info(
@@ -94,6 +108,31 @@ class TRTViTAttentionRewriter(TRTAttentionRewriter):
             head_size,
             orig_q_input,
         )
+
+    def _bake_seqlens(self, graph: OnnxGraph, node: NodeProto) -> bool:
+        """Bake cu_seqlens as a constant input if possible."""
+        # For now ViT attention is only for Qwen-VL series, so seq_len is
+        # the 1st dimension of graph input.
+        input_shape = graph.tensor_shape(graph.input[0].name)
+        if len(input_shape) == 2:
+            seq_len = input_shape[0]
+        elif len(input_shape) == 3:
+            seq_len = input_shape[1]
+        else:
+            logger.warning("Unexpected graph input shape, can't bake cu_seqlens.")
+            return False
+        if not isinstance(seq_len, int) or seq_len <= 0:
+            logger.warning("Symbolic seq_len, can't bake cu_seqlens.")
+            return False
+        cu_seqlens = make_constant("cu_seqlens", np.array([0, seq_len], dtype=np.int32))
+        node.input[3] = cu_seqlens.output[0]
+        self += cu_seqlens
+        seqlen_carrier = make_constant(
+            "max_seqlen_carrier", np.array([seq_len], dtype=np.int32)
+        )
+        node.input[4] = seqlen_carrier.output[0]
+        self += seqlen_carrier
+        return True
 
     def _add_shared_inputs(self, graph: OnnxGraph):
         """Add shared inputs to the graph for all ViT attention nodes."""


### PR DESCRIPTION
- The shape input to reshape is wrongly made a 2-D vector, fix
  it to 1-D.
- Upgrade the default onnx opset to 20 and ir version to 10
- When replace TRTVitAttention, try to bake cu_seqlens and
  max_seqlen_carriers.
